### PR TITLE
GraphQL Money and TForm enhancements

### DIFF
--- a/packages/controls/src/TForm.js
+++ b/packages/controls/src/TForm.js
@@ -2,6 +2,7 @@
 
 import React, {Component} from 'react';
 import isEmpty from 'lodash/isEmpty';
+import isString from 'lodash/isString';
 import {Formik} from 'formik';
 import {Message} from 'semantic-ui-react';
 
@@ -30,7 +31,7 @@ export default class TForm extends Component<Props> {
 	props: Props;
 
 	renderForm = args => {
-		const {errors: warnings, touched} = args;
+		const {errors: warnings, touched, handleChange, setFieldValue, ...rest} = args;
 		const {errors, numFields, render} = this.props;
 
 		return render({
@@ -68,7 +69,19 @@ export default class TForm extends Component<Props> {
 			fieldError(fieldName) {
 				return !!(touched[fieldName] && warnings[fieldName]);
 			},
-			...args,
+			handleChange(evOrName) {
+				if (evOrName.nativeEvent) return handleChange(evOrName);
+				if (isString(evOrName)) {
+					return val => {
+						setFieldValue(evOrName, val);
+					};
+				}
+				throw new Error('TForm expects handleChange to receive a SyntheticEvent or a string value of the field name');
+			},
+			errors: warnings,
+			touched,
+			setFieldValue,
+			...rest,
 		});
 	};
 

--- a/packages/controls/stories/TForm.story.js
+++ b/packages/controls/stories/TForm.story.js
@@ -5,6 +5,7 @@ import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
 import {Container, Form} from 'semantic-ui-react';
 import TForm from '../src/TForm';
+import MaskedInput from '../src/MaskedInput';
 
 const stories = storiesOf('TForm', module);
 
@@ -16,6 +17,10 @@ function renderForm({handleChange, handleSubmit, values}) {
 			<Form.Field width={6}>
 				<label>Enter some text</label>
 				<input name="text" value={values.text} onChange={handleChange}/>
+			</Form.Field>
+			<Form.Field width={6}>
+				<label>Custom input</label>
+				<MaskedInput name="masked" value={values.masked} onChange={handleChange('masked')}/>
 			</Form.Field>
 			<Form.Button onClick={handleSubmit}>Submit</Form.Button>
 		</Form>

--- a/packages/money/src/graphql/GraphQLMoney.js
+++ b/packages/money/src/graphql/GraphQLMoney.js
@@ -1,7 +1,9 @@
 import {GraphQLError} from 'graphql/error';
-import {GraphQLScalarType} from 'graphql';
+import {GraphQLScalarType} from 'graphql/type';
 import {Kind} from 'graphql/language';
 import isString from 'lodash/isString';
+import isObject from 'lodash/isObject';
+import isNumber from 'lodash/isNumber';
 import Money from 'js-money';
 import {makeMoney} from '../util';
 
@@ -10,12 +12,14 @@ const GraphQLMoney = new GraphQLScalarType({
 	description: 'JS-Money object',
 	// Parses variable values (JSON => JSON)
 	parseValue(value) {
-		if (isString(value)) return makeMoney(Number(value));
 		return makeMoney(value);
 	},
 	// Called when the value is being sent to the client
 	serialize(value) {
 		if (value instanceof Money) return value;
+		if (isObject(value) && value.amount && value.currency) return makeMoney(value);
+		if (isString(value)) return makeMoney(value);
+		if (isNumber(value)) return makeMoney(value);
 		throw new GraphQLError('Trying to serialize a non-primitive');
 	},
 	// Parses GraphQL language AST into the value. (AST => JSON)


### PR DESCRIPTION
* Fixed GraphQL Money scalar to accept object, string and number values.
* Enhanced TForm handleChange() to be passed a field name to accommodate controls that don't use SyntheticEvent.