### PR TITLE
Fix bug where `transformObjectsToMoney()` ignored objects with amount…

### DIFF
--- a/packages/money/src/util.js
+++ b/packages/money/src/util.js
@@ -54,7 +54,7 @@ export function transformObjectsToMoney(obj) {
 		return map(obj, v => transformObjectsToMoney(v));
 	}
 	if (isObject(obj)) {
-		if (obj.amount && obj.currency) return new Money(obj.amount, obj.currency);
+		if (has(obj, 'amount') && has(obj, 'currency')) return new Money(obj.amount, obj.currency);
 		return transform(obj, (result, value, key) => {
 			result[key] = transformObjectsToMoney(value); // eslint-disable-line no-param-reassign
 		}, {});

--- a/packages/money/tests/__snapshots__/util.test.js.snap
+++ b/packages/money/tests/__snapshots__/util.test.js.snap
@@ -41,6 +41,21 @@ Object {
 
 exports[`Make Money should throw an error if something wrong is passed to it 1`] = `"Can't convert value to Money: [object Object]."`;
 
+exports[`Transforms should transform objects of zero value to Money 1`] = `
+Object {
+  "field1": Object {
+    "amount": 0,
+    "currency": "CAD",
+  },
+  "field2": Array [
+    Object {
+      "amount": 500,
+      "currency": "CAD",
+    },
+  ],
+}
+`;
+
 exports[`Transforms should transform objects to Money 1`] = `
 Object {
   "field1": Object {

--- a/packages/money/tests/util.test.js
+++ b/packages/money/tests/util.test.js
@@ -81,4 +81,14 @@ describe('Transforms', () => {
 		expect(val.field2[0]).toBeInstanceOf(Money);
 		expect(val).toMatchSnapshot();
 	});
+
+	it('should transform objects of zero value to Money', () => {
+		const val = transformObjectsToMoney({
+			field1: {amount: 0, currency: 'CAD'},
+			field2: [{amount: 500, currency: 'CAD'}],
+		});
+		expect(val.field1).toBeInstanceOf(Money);
+		expect(val.field2[0]).toBeInstanceOf(Money);
+		expect(val).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
…s of 0.